### PR TITLE
Reject out-of-range secp256k1 keys in wif and xprv apps

### DIFF
--- a/src/bipsea/apps/shared.py
+++ b/src/bipsea/apps/shared.py
@@ -1,4 +1,19 @@
+from ecdsa import SECP256k1
+
+
 def hardened_int(segment: str) -> int:
     if not segment.endswith("'"):
         raise ValueError(f"Expected hardened segment, got {segment}")
     return int(segment[:-1])
+
+
+def validate_secp256k1_key(key: bytes) -> bytes:
+    # BIP-32: in case parse256(key) >= n or key = 0 the secret is invalid, and
+    # one should proceed with the next index. (Probability lower than 1 in 2**127.)
+    secret = int.from_bytes(key, "big")
+    if secret == 0 or secret >= SECP256k1.order:
+        raise ValueError(
+            "Rare invalid secret key (0 or >= secp256k1 order). "
+            "Retry with the next child index."
+        )
+    return key

--- a/src/bipsea/apps/wif/app.py
+++ b/src/bipsea/apps/wif/app.py
@@ -3,6 +3,7 @@ from typing import Any
 import base58
 
 from bipsea.app_protocol import Param, TestVector
+from bipsea.apps.shared import validate_secp256k1_key
 
 
 class WifApp:
@@ -20,7 +21,7 @@ class WifApp:
         return {}
 
     def apply(self, entropy: bytes, network: str = "mainnet", **_) -> dict[str, Any]:
-        trimmed = entropy[:32]
+        trimmed = validate_secp256k1_key(entropy[:32])
         prefix = b"\x80" if network == "mainnet" else b"\xef"
         suffix = b"\x01"  # use with compressed public keys because BIP-32
         extended = prefix + trimmed + suffix

--- a/src/bipsea/apps/xprv/app.py
+++ b/src/bipsea/apps/xprv/app.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from bipsea.app_protocol import Param, TestVector
+from bipsea.apps.shared import validate_secp256k1_key
 from bipsea.bip32 import VERSIONS, ExtendedKey
 
 
@@ -19,16 +20,17 @@ class XprvApp:
         return {}
 
     def apply(self, entropy: bytes, **_) -> dict[str, Any]:
+        key = validate_secp256k1_key(entropy[32:])
         derived_key = ExtendedKey(
             version=VERSIONS["mainnet"]["private"],
             depth=bytes(1),
             finger=bytes(4),
             child_number=bytes(4),
             chain_code=entropy[:32],
-            data=bytes(1) + entropy[32:],
+            data=bytes(1) + key,
         )
         return {
-            "entropy": entropy[32:],
+            "entropy": key,
             "application": str(derived_key),
         }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from click import Choice, IntRange
 from click.testing import CliRunner
 from data.bip39_vectors import VECTORS
 from data.bip85_vectors import COMMON_XPRV
+from ecdsa import SECP256k1
 
 from bipsea.app_protocol import Param
 from bipsea.apps.base64.app import app as base64_app
@@ -18,7 +19,9 @@ from bipsea.apps.base85.app import app as base85_app
 from bipsea.apps.dice.app import app as dice_app
 from bipsea.apps.hex.app import app as hex_app
 from bipsea.apps.mnemonic.app import app as mnemonic_app
+from bipsea.apps.shared import validate_secp256k1_key
 from bipsea.apps.wif.app import app as wif_app
+from bipsea.apps.xprv.app import app as xprv_app
 from bipsea.bip32types import validate_prv_str
 from bipsea.bip39 import LANGUAGES, validate_mnemonic_words
 from bipsea.bipsea import ISO_TO_LANGUAGE, N_WORDS_ALLOWED, cli, try_for_pipe_input
@@ -481,3 +484,29 @@ class TestCliAdapter:
                 flags, kwargs = param_to_click_option(param)
                 assert flags == param.flags
                 assert "type" in kwargs
+
+
+class TestSecp256k1Validation:
+    N = SECP256k1.order
+
+    def test_accepts_boundary_keys(self):
+        for secret in (1, self.N - 1):
+            key = secret.to_bytes(32, "big")
+            assert validate_secp256k1_key(key) == key
+
+    @pytest.mark.parametrize("secret", [0, N, N + 1, 2**256 - 1])
+    def test_rejects_out_of_range(self, secret):
+        with pytest.raises(ValueError, match="Rare invalid secret key"):
+            validate_secp256k1_key(secret.to_bytes(32, "big"))
+
+    def test_wif_rejects_out_of_range(self):
+        # entropy[:32] is the WIF secret exponent
+        entropy = b"\xff" * 32 + b"\x00" * 32
+        with pytest.raises(ValueError, match="Rare invalid secret key"):
+            wif_app.apply(entropy)
+
+    def test_xprv_rejects_out_of_range(self):
+        # entropy[32:] is the XPRV private key
+        entropy = b"\x00" * 32 + b"\xff" * 32
+        with pytest.raises(ValueError, match="Rare invalid secret key"):
+            xprv_app.apply(entropy)


### PR DESCRIPTION
## Summary

The `wif` (`2'`) and `xprv` (`32'`) applications take a 32-byte slice of the BIP-85 entropy and use it directly as a secp256k1 secret key, without checking that it is a valid scalar. A secret of `0` or `>= n` (the curve order) is not a usable key. For such a value, different downstream libraries would either throw, silently reduce mod `n`, or emit a degenerate key, so the derivation was underspecified for that case.

This is astronomically rare (~1 in 2**127, the same bound BIP-32 gives), so it will realistically never occur in practice. But it should fail loudly and deterministically rather than depend on the consumer, and I was surprised we didn't already do this given the analogous BIP-32 check already in the codebase.

## Changes

- Add `validate_secp256k1_key()` to `apps/shared.py`. It raises `ValueError` if the 32-byte value is `0` or `>= SECP256k1.order`, mirroring the wording of the existing `validate_private_child_params` in `bip32.py`. The caller should retry with the next child index.
- Call it from `WifApp.apply` (`entropy[:32]`, the secret exponent) and `XprvApp.apply` (`entropy[32:]`, the private key).
- Add `TestSecp256k1Validation` with boundary cases (`1`, `n-1` accepted; `0`, `n`, `n+1`, `2**256-1` rejected) and app-level cases that a crafted entropy makes `wif`/`xprv` raise.

The existing test vectors are unaffected (their keys are all in range), and the full suite plus `make check` pass.

## Note

This intentionally does not touch the Nostr application in #70, which is not on `main` yet and produces a secp256k1 key the same way. If this lands, #70 should reuse `validate_secp256k1_key` for the same reason. It would be good to settle the policy once and keep the BIP-85 text (bitcoin/bips#2126) consistent with it.

## Test plan

- [x] `poetry run pytest -m ""` (full suite passes)
- [x] `make check` (black, isort, flake8, version-sync all clean)
- [x] New tests cover the helper, the boundaries, and both apps

Made with [Cursor](https://cursor.com)